### PR TITLE
Add ProjectsIsland toggle test

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "test": "vitest"
   },
   "dependencies": {
     "@astrojs/mdx": "^3.1.5",
@@ -28,6 +29,8 @@
     "sharp": "^0.31.3"
   },
   "devDependencies": {
-    "@tailwindcss/typography": "^0.5.7"
+    "@tailwindcss/typography": "^0.5.7",
+    "vitest": "^1.4.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/tests/projectsIsland.test.ts
+++ b/tests/projectsIsland.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('ProjectsIsland toggle', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="extra-projects" class="hidden"></div>
+      <button id="toggleButton">See more</button>
+    `;
+
+    document.getElementById('toggleButton')!.addEventListener('click', () => {
+      const extraProjects = document.getElementById('extra-projects')!;
+      const button = document.getElementById('toggleButton')!;
+      if (extraProjects.classList.contains('hidden')) {
+        extraProjects.classList.remove('hidden');
+        button.classList.add('hidden');
+      } else {
+        extraProjects.classList.add('hidden');
+        button.textContent = 'See more';
+      }
+    });
+  });
+
+  it('shows and hides extra projects', () => {
+    const button = document.getElementById('toggleButton')!;
+    const extraProjects = document.getElementById('extra-projects')!;
+
+    button.click();
+    expect(extraProjects.classList.contains('hidden')).toBe(false);
+    expect(button.classList.contains('hidden')).toBe(true);
+
+    button.click();
+    expect(extraProjects.classList.contains('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest and jsdom dependencies
- add test script
- create DOM-based test for ProjectsIsland toggle

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdd3660c0832da992905384bf5bb9