### PR TITLE
Update Calendly scheduling URL

### DIFF
--- a/src/components/SideBar.astro
+++ b/src/components/SideBar.astro
@@ -68,7 +68,7 @@ const sectionHref = (hash: string) => `${homeHref}${hash}`;
         <LinkedinIcon />
       </a>
       <a
-        href="https://calendly.com/d/cwgs-txt-yqj/meeting"
+        href="https://calendly.com/ferranhpv3/30min"
         target="_blank"
         class="mx-3"
         aria-label="Calendly"

--- a/src/islands/SocialButtons.astro
+++ b/src/islands/SocialButtons.astro
@@ -24,7 +24,7 @@ const { letsConnect, seeTheSourceCode, scheduleMeeting } =
     </a-->
     <a
         class="btn btn-outline fontButtons"
-        href="https://calendly.com/d/cwgs-txt-yqj/meeting"
+        href="https://calendly.com/ferranhpv3/30min"
         target="_blank"
         role="button"
     >


### PR DESCRIPTION
### Motivation
- Replace the outdated Calendly link with the new personal scheduling URL `https://calendly.com/ferranhpv3/30min` so site buttons point to the correct booking page.

### Description
- Updated the Calendly `href` to `https://calendly.com/ferranhpv3/30min` in `src/components/SideBar.astro` and `src/islands/SocialButtons.astro`.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b328a835fc832db239e5c26c91fd05)