### PR TITLE
Set VirtualCave / Inditex end date to 07/2026 and hardcode localized duration

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -45,7 +45,7 @@ export interface Translation {
   experience: {
     title: string;
     durationLabels: DurationLabels;
-    durationConfig: Record<string, { start: string; end?: string }>;
+    durationConfig: Record<string, { start: string; end?: string; duration?: string }>;
     items: Array<{
       title: string;
       subtitle: string;
@@ -310,7 +310,7 @@ const translations: Record<LanguageCode, Translation> = {
       durationConfig: {
         freelance: { start: "2023-06-01" },
         uoc: { start: "2025-01-01" },
-        inditex: { start: "2025-07-01" },
+        inditex: { start: "2025-07-01", duration: "1 year" },
       },
       items: [
         {
@@ -325,8 +325,8 @@ const translations: Record<LanguageCode, Translation> = {
         },
         {
           title: "Senior Backend Developer",
-          subtitle: "From 07/2025 to current at VirtualCave S.L. - {inditex} - Remote work",
-          desc: "- Inditex (07/2025 - Current - {inditex}): Responsible for developing event-driven microservices and integration flows, leveraging Kafka and gRPC. Applied clean architecture and DDD to ensure maintainability of high-performance applications while improving the Inditex stock source and implementing new features.",
+          subtitle: "From 07/2025 to 07/2026 at VirtualCave S.L. - {inditex} - Remote work",
+          desc: "- Inditex (07/2025 - 07/2026 - {inditex}): Responsible for developing event-driven microservices and integration flows, leveraging Kafka and gRPC. Applied clean architecture and DDD to ensure maintainability of high-performance applications while improving the Inditex stock source and implementing new features.",
         },
         {
           title: "Programmer Analyst and DevOps Engineer",
@@ -521,7 +521,7 @@ const translations: Record<LanguageCode, Translation> = {
       durationConfig: {
         freelance: { start: "2023-06-01" },
         uoc: { start: "2025-01-01" },
-        inditex: { start: "2025-07-01" },
+        inditex: { start: "2025-07-01", duration: "1 año" },
       },
       items: [
         {
@@ -536,8 +536,8 @@ const translations: Record<LanguageCode, Translation> = {
         },
         {
           title: "Desarrollador Backend Senior",
-          subtitle: "Desde 07/2025 hasta la actualidad en VirtualCave S.L. - {inditex} - Trabajo remoto",
-          desc: "- Inditex (07/2025 - Current - {inditex}): Responsable del desarrollo de microservicios orientados a eventos y flujos de integración utilizando Kafka y gRPC. Aplicación de arquitectura limpia y DDD para garantizar el mantenimiento de aplicaciones de alto rendimiento mejorando la fuente de stock de Inditex e incorporando nuevas funcionalidades.",
+          subtitle: "Desde 07/2025 hasta 07/2026 en VirtualCave S.L. - {inditex} - Trabajo remoto",
+          desc: "- Inditex (07/2025 - 07/2026 - {inditex}): Responsable del desarrollo de microservicios orientados a eventos y flujos de integración utilizando Kafka y gRPC. Aplicación de arquitectura limpia y DDD para garantizar el mantenimiento de aplicaciones de alto rendimiento mejorando la fuente de stock de Inditex e incorporando nuevas funcionalidades.",
         },
         {
           title: "Analista Programador y DevOps",
@@ -761,7 +761,7 @@ const translations: Record<LanguageCode, Translation> = {
       durationConfig: {
         freelance: { start: "2023-06-01" },
         uoc: { start: "2025-01-01" },
-        inditex: { start: "2025-07-01" },
+        inditex: { start: "2025-07-01", duration: "1 any" },
       },
       items: [
         {
@@ -776,8 +776,8 @@ const translations: Record<LanguageCode, Translation> = {
         },
         {
           title: "Desenvolupador Backend Sènior",
-          subtitle: "Des de 07/2025 fins a l'actualitat a VirtualCave S.L. - {inditex} - Treball remot",
-          desc: "- Inditex (07/2025 - Actualitat - {inditex}): Responsable del desenvolupament de microserveis orientats a esdeveniments i fluxos d'integració utilitzant Kafka i gRPC. Aplicació d'arquitectura neta i DDD per garantir el manteniment d'aplicacions d'alt rendiment, millorant la font d'estoc d'Inditex i incorporant noves funcionalitats.",
+          subtitle: "Des de 07/2025 fins a 07/2026 a VirtualCave S.L. - {inditex} - Treball remot",
+          desc: "- Inditex (07/2025 - 07/2026 - {inditex}): Responsable del desenvolupament de microserveis orientats a esdeveniments i fluxos d'integració utilitzant Kafka i gRPC. Aplicació d'arquitectura neta i DDD per garantir el manteniment d'aplicacions d'alt rendiment, millorant la font d'estoc d'Inditex i incorporant noves funcionalitats.",
         },
         {
           title: "Analista Programador i Enginyer DevOps",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -326,7 +326,7 @@ const translations: Record<LanguageCode, Translation> = {
         {
           title: "Senior Backend Developer",
           subtitle: "From 07/2025 to 07/2026 at VirtualCave S.L. - {inditex} - Remote work",
-          desc: "- Inditex (07/2025 - 07/2026 - {inditex}): Responsible for developing event-driven microservices and integration flows, leveraging Kafka and gRPC. Applied clean architecture and DDD to ensure maintainability of high-performance applications while improving the Inditex stock source and implementing new features.",
+          desc: "- Inditex (07/2025 - 07/2026): Responsible for developing event-driven microservices and integration flows, leveraging Kafka and gRPC. Applied clean architecture and DDD to ensure maintainability of high-performance applications while improving the Inditex stock source and implementing new features.",
         },
         {
           title: "Programmer Analyst and DevOps Engineer",
@@ -537,7 +537,7 @@ const translations: Record<LanguageCode, Translation> = {
         {
           title: "Desarrollador Backend Senior",
           subtitle: "Desde 07/2025 hasta 07/2026 en VirtualCave S.L. - {inditex} - Trabajo remoto",
-          desc: "- Inditex (07/2025 - 07/2026 - {inditex}): Responsable del desarrollo de microservicios orientados a eventos y flujos de integración utilizando Kafka y gRPC. Aplicación de arquitectura limpia y DDD para garantizar el mantenimiento de aplicaciones de alto rendimiento mejorando la fuente de stock de Inditex e incorporando nuevas funcionalidades.",
+          desc: "- Inditex (07/2025 - 07/2026): Responsable del desarrollo de microservicios orientados a eventos y flujos de integración utilizando Kafka y gRPC. Aplicación de arquitectura limpia y DDD para garantizar el mantenimiento de aplicaciones de alto rendimiento mejorando la fuente de stock de Inditex e incorporando nuevas funcionalidades.",
         },
         {
           title: "Analista Programador y DevOps",
@@ -777,7 +777,7 @@ const translations: Record<LanguageCode, Translation> = {
         {
           title: "Desenvolupador Backend Sènior",
           subtitle: "Des de 07/2025 fins a 07/2026 a VirtualCave S.L. - {inditex} - Treball remot",
-          desc: "- Inditex (07/2025 - 07/2026 - {inditex}): Responsable del desenvolupament de microserveis orientats a esdeveniments i fluxos d'integració utilitzant Kafka i gRPC. Aplicació d'arquitectura neta i DDD per garantir el manteniment d'aplicacions d'alt rendiment, millorant la font d'estoc d'Inditex i incorporant noves funcionalitats.",
+          desc: "- Inditex (07/2025 - 07/2026): Responsable del desenvolupament de microserveis orientats a esdeveniments i fluxos d'integració utilitzant Kafka i gRPC. Aplicació d'arquitectura neta i DDD per garantir el manteniment d'aplicacions d'alt rendiment, millorant la font d'estoc d'Inditex i incorporant noves funcionalitats.",
         },
         {
           title: "Analista Programador i Enginyer DevOps",

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -326,7 +326,7 @@ const translations: Record<LanguageCode, Translation> = {
         {
           title: "Senior Backend Developer",
           subtitle: "From 07/2025 to 07/2026 at VirtualCave S.L. - {inditex} - Remote work",
-          desc: "- Inditex (07/2025 - 07/2026): Responsible for developing event-driven microservices and integration flows, leveraging Kafka and gRPC. Applied clean architecture and DDD to ensure maintainability of high-performance applications while improving the Inditex stock source and implementing new features.",
+          desc: "- Inditex: Responsible for developing event-driven microservices and integration flows, leveraging Kafka and gRPC. Applied clean architecture and DDD to ensure maintainability of high-performance applications while improving the Inditex stock source and implementing new features.",
         },
         {
           title: "Programmer Analyst and DevOps Engineer",
@@ -537,7 +537,7 @@ const translations: Record<LanguageCode, Translation> = {
         {
           title: "Desarrollador Backend Senior",
           subtitle: "Desde 07/2025 hasta 07/2026 en VirtualCave S.L. - {inditex} - Trabajo remoto",
-          desc: "- Inditex (07/2025 - 07/2026): Responsable del desarrollo de microservicios orientados a eventos y flujos de integración utilizando Kafka y gRPC. Aplicación de arquitectura limpia y DDD para garantizar el mantenimiento de aplicaciones de alto rendimiento mejorando la fuente de stock de Inditex e incorporando nuevas funcionalidades.",
+          desc: "- Inditex: Responsable del desarrollo de microservicios orientados a eventos y flujos de integración utilizando Kafka y gRPC. Aplicación de arquitectura limpia y DDD para garantizar el mantenimiento de aplicaciones de alto rendimiento mejorando la fuente de stock de Inditex e incorporando nuevas funcionalidades.",
         },
         {
           title: "Analista Programador y DevOps",
@@ -777,7 +777,7 @@ const translations: Record<LanguageCode, Translation> = {
         {
           title: "Desenvolupador Backend Sènior",
           subtitle: "Des de 07/2025 fins a 07/2026 a VirtualCave S.L. - {inditex} - Treball remot",
-          desc: "- Inditex (07/2025 - 07/2026): Responsable del desenvolupament de microserveis orientats a esdeveniments i fluxos d'integració utilitzant Kafka i gRPC. Aplicació d'arquitectura neta i DDD per garantir el manteniment d'aplicacions d'alt rendiment, millorant la font d'estoc d'Inditex i incorporant noves funcionalitats.",
+          desc: "- Inditex: Responsable del desenvolupament de microserveis orientats a esdeveniments i fluxos d'integració utilitzant Kafka i gRPC. Aplicació d'arquitectura neta i DDD per garantir el manteniment d'aplicacions d'alt rendiment, millorant la font d'estoc d'Inditex i incorporant noves funcionalitats.",
         },
         {
           title: "Analista Programador i Enginyer DevOps",

--- a/src/islands/ExperienceIsland.astro
+++ b/src/islands/ExperienceIsland.astro
@@ -29,7 +29,7 @@ function calcDuration(startStr: string, endStr?: string) {
 const computedDurations = Object.fromEntries(
   Object.entries(durationConfig).map(([key, value]) => [
     key,
-    calcDuration(value.start, value.end),
+    value.duration ?? calcDuration(value.start, value.end),
   ]),
 );
 


### PR DESCRIPTION
### Motivation
- The experience entry for VirtualCave/Inditex should show an explicit end date of July 2026 and a fixed localized duration so the value does not change each time the page is viewed.
- Provide a localized, hardcoded duration for the Inditex placeholder to avoid runtime recalculation and to ensure consistent display across languages.

### Description
- Extended the `durationConfig` type to accept an optional `duration?: string` field and added `duration` values for the `inditex` key in English, Spanish and Catalan translations (e.g. `"1 year"`, `"1 año"`, `"1 any"`).
- Updated the `inditex` experience text in `src/i18n/translations.ts` to show `07/2026` as the end date in English, Spanish and Catalan subtitles and descriptions.
- Modified `src/islands/ExperienceIsland.astro` to prefer `value.duration` when present and only fall back to calculating the duration from dates, by using `value.duration ?? calcDuration(value.start, value.end)` when computing placeholders.

### Testing
- Ran `npm run build` and the build completed successfully with server and client artifacts produced.
- Searched the codebase and build output for `07/2026` and the localized duration strings (`1 year`, `1 año`, `1 any`) and confirmed they appear in the modified files and output.
- Verified the site rendered without errors during the build step and there were no blocking issues reported by the build process.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55f07d6c3c832d9b95ad27d3486ad7)